### PR TITLE
Fix loading flash issue when sending magic link

### DIFF
--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -44,8 +44,6 @@ export default function SignInPage() {
       email,
       callbackUrl: "/",
     });
-
-    setLoading(false);
   };
 
   if (loading || status === "loading") {


### PR DESCRIPTION
This PR fixes an issue that causes the loading screen to flash momentarily before the email sent message is shown.